### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,14 @@ jobs:
           sudo add-apt-repository 'deb http://gb.archive.ubuntu.com/ubuntu jammy main'
           sudo add-apt-repository 'deb http://gb.archive.ubuntu.com/ubuntu jammy-security main'
           sudo apt-get update
-          sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt install -y \
+            libwebkit2gtk-4.0-37=2.36.0-2ubuntu1 \
+            libwebkit2gtk-4.0-dev=2.36.0-2ubuntu1 \
+            libjavascriptcoregtk-4.0-18=2.36.0-2ubuntu1 \
+            libjavascriptcoregtk-4.0-dev=2.36.0-2ubuntu1 \
+            gir1.2-javascriptcoregtk-4.0=2.36.0-2ubuntu1 \
+            gir1.2-webkit2-4.0=2.36.0-2ubuntu1;
+          sudo apt install -y libopengl0
       - name: install frontend dependencies
         run: npm install 
       - uses: tauri-apps/tauri-action@v0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ A mod manager for Dredge mods using the Winch mod loader. Can download and insta
 
 ![Mod manager screenshot](https://github.com/DREDGE-Mods/DredgeModManager/assets/22628069/8bf559b9-d952-4a9b-92c7-ad0d7fd282d8)
 
-## Development
+## Troubleshooting (for users)
+
+_**The manager prompted me to install a new update, but nothing changed!**_
+
+We're not sure why that happens some times, just uninstall the manager and reinstall it from here.
+
+## Development (for devs)
 
 To run you go `npm install` -> `npm run tauri dev`
 
@@ -32,5 +38,11 @@ The action will then create a draft release from that dev->main PR. Make sure to
 To [bdlm-dev](https://github.com/bdlm-dev) for redoing the front-end (twice). 
 
 To [Bwc9876](https://github.com/Bwc9876) for answering my questions about Tauri/rust/actions/everything.
+
+To [dasea/SeaKestrel](https://github.com/SeaKestrel) for Linux support.
+
+To [MegaPiggy](https://github.com/MegaPiggy) for maintenance.
+
+Originally made and maintained by [xen-42](https://github.com/xen-42).
 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To regenerate the icon replace `app-icon.png` and run `npm run tauri icon`.
 
 First make sure to search for the previous version number in the manager files and update it to the new value. Follow semver.
 
-Make a PR from dev into main. When the PR is actually merged, the commit message will be used as the changelog, so update it accordingly. We should really have the release action copy the description of the PR into there too.
+Make a PR from dev into main. When the PR is actually merged, the commit message will be used as the changelog, so update it accordingly.
 
 The action will then create a draft release from that dev->main PR. Make sure to write in the changelog into the description of the release, and change the tag to the format vX.X.X (put actual version number). Then publish.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ _**The manager prompted me to install a new update, but nothing changed!**_
 
 We're not sure why that happens some times, just uninstall the manager and reinstall it from here.
 
+_**The manager instantly closes when I try to launch it**_
+
+Did you at some point uninstall Microsft Edge from Windows? As a Tauri app, the Dredge Mod Manager uses Microsoft Edge Runtime2.
+
 ## Development (for devs)
 
 To run you go `npm install` -> `npm run tauri dev`


### PR DESCRIPTION
Adding the right package for compiling on Ubuntu, adding support for Fedora

Fixing the error
```
./dredge-mod-manager_0.1.5_amd64.AppImage

** (dredge-mod-manager:310160): WARNING **: 21:16:39.483: webkit_settings_set_enable_offline_web_application_cache is deprecated and does nothing.
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

Source https://github.com/unxsist/jet-pilot/commit/f9fcf2e8d661a1a9abef7f7dfae94c8c48295345