### PR TITLE
Fix linux support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dredge_mod_manager",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dredge_mod_manager",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.4.0",
         "@popperjs/core": "^2.11.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dredge_mod_manager",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -692,7 +692,7 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dredge_mod_manager"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "directories",
  "open 4.2.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dredge_mod_manager"
-version = "0.1.5"
+version = "0.1.6"
 description = "Mod manager application for DREDGE"
 authors = ["xen-42"]
 license = "MIT"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -291,11 +291,9 @@ fn patch_proton_pfx(prefix: String) {
 #[tauri::command]
 fn start_game(dredge_path : String) -> Result<(), String> {
     let is_windows = cfg!(windows);
-
-    let is_steamapi_present: bool = Path::new(&format!("{}/DREDGE_Data/Plugins/x86/steam_api.dll", dredge_path)).exists();
-    let is_eos_present: bool = Path::new(&format!("{}/DREDGE_Data/Plugins/x86/EOSSDK-Win32-Shipping.dll", dredge_path)).exists();
-    let is_gog: bool = Path::new(&format!("{}/goggame-1744110647.ico", dredge_path)).exists();
-
+    let is_steamapi_present = Path::new(&format!("{}/DREDGE_Data/Plugins/x86/steam_api.dll", dredge_path)).exists();
+    let is_eos_present = Path::new(&format!("{}/DREDGE_Data/Plugins/x86/EOSSDK-Win32-Shipping.dll", dredge_path)).exists();
+    let is_gog = Path::new(&format!("{}/goggame-1744110647.ico", dredge_path)).exists();
     let is_steam = is_steamapi_present && !is_gog && !is_eos_present;
 
     let mut run_exe = false;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -303,7 +303,7 @@ fn start_game(dredge_path : String) -> Result<(), String> {
     };
 
     if is_windows {
-        if Path::new(&format!("{}/WinchLauncher.exe", dredge_path)).exists() && !run_exe {
+        if Path::new(&format!("{}/WinchLauncher.exe", dredge_path)).exists() && !is_gog && !run_exe {
             match Command::new(format!("{}/WinchLauncher.exe", dredge_path)).spawn() {
                 Ok(_) => return Ok(()),
                 // Fallback to just using the exe if it fails spectacularly 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -259,6 +259,7 @@ fn write_enabled_mods(json : HashMap<String, bool>, enabled_mods_path : String) 
 #[tauri::command]
 fn start_game(dredge_path : String) -> Result<(), String> {
     let is_windows = cfg!(windows);
+    let is_steam: bool = Path::new(&format!("{}/DREDGE_Data/Plugins/x86/steam_api.dll", dredge_path)).exists();
 
     let mut run_exe = false;
     match winch_config::load_winch_config(dredge_path.to_string()) {
@@ -284,13 +285,45 @@ fn start_game(dredge_path : String) -> Result<(), String> {
             }   
         }
     }
+
+    // Linux support by SeaKestrel and Zarashigal.
     else {
-        // TODO: Make linux work with WinchLauncher
-        // ^ Done. Use these environment vars! - Love, Zarashigal.
+
+        // If we're on linux and run steam... run it via proton!
+        
+        /* 
+            
+            TODO: There have been requests to add this feature for years now...
+            We should find a way to run the environment variables via this command.
+            Any ideas? Checks are already implemented, we just need a way to run the game now. - Zarashigal
+
+         */ 
+        
+        /*
+
+            if is_steam {
+                println!("DEBUG: Running on LINUX/STEAM.");
+                match Command::new("steam").env("WINEDLLOVERRIDES","winhttp.dll=n,b").args(["-applaunch", "1562430"]).spawn() {
+                    Ok(_) => return Ok(()),
+                    Err(_) => return Err("Failed to start DREDGE.exe. Is the game directory correct?".to_string())
+                } 
+            }
+
+            else {
+                println!("DEBUG: Running on LINUX/GOG.");
+                match Command::new("wine").env("WINEDLLOVERRIDES","winhttp.dll=n,b").args([format!("{}/DREDGE.exe", dredge_path)]).spawn() {
+                    Ok(_) => return Ok(()),
+                    Err(_) => return Err("Failed to start DREDGE.exe. Is the game directory correct?".to_string())
+                }
+            }
+        
+        */
+
         match Command::new("wine").env("WINEDLLOVERRIDES","winhttp.dll=n,b").args([format!("{}/DREDGE.exe", dredge_path)]).spawn() {
             Ok(_) => return Ok(()),
             Err(_) => return Err("Failed to start DREDGE.exe. Is the game directory correct?".to_string())
-        }   
+        }
+
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -286,7 +286,8 @@ fn start_game(dredge_path : String) -> Result<(), String> {
     }
     else {
         // TODO: Make linux work with WinchLauncher
-        match Command::new("wine").args([format!("{}/DREDGE.exe", dredge_path)]).spawn() {
+        // ^ Done. Use these environment vars! - Love, Zarashigal.
+        match Command::new("wine").env("WINEDLLOVERRIDES","winhttp.dll=n,b").args([format!("{}/DREDGE.exe", dredge_path)]).spawn() {
             Ok(_) => return Ok(()),
             Err(_) => return Err("Failed to start DREDGE.exe. Is the game directory correct?".to_string())
         }   

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -261,7 +261,7 @@ fn write_enabled_mods(json : HashMap<String, bool>, enabled_mods_path : String) 
 }
 
 // Patch for steamdeck and steam-based dredge to load winhttp instead of builtin.
-fn patch_protonPFX(prefix: String) {
+fn patch_proton_pfx(prefix: String) {
 
     // Put prefix path here in case we ever need to change this!!
     let file_path = format!("{prefix}/user.reg");
@@ -291,7 +291,12 @@ fn patch_protonPFX(prefix: String) {
 #[tauri::command]
 fn start_game(dredge_path : String) -> Result<(), String> {
     let is_windows = cfg!(windows);
-    let is_steam: bool = Path::new(&format!("{}/DREDGE_Data/Plugins/x86/steam_api.dll", dredge_path)).exists();
+
+    let is_steamapi_present: bool = Path::new(&format!("{}/DREDGE_Data/Plugins/x86/steam_api.dll", dredge_path)).exists();
+    let is_eos_present: bool = Path::new(&format!("{}/DREDGE_Data/Plugins/x86/EOSSDK-Win32-Shipping.dll", dredge_path)).exists();
+    let is_gog: bool = Path::new(&format!("{}/goggame-1744110647.ico", dredge_path)).exists();
+
+    let is_steam = is_steamapi_present && !is_gog && !is_eos_present;
 
     let mut run_exe = false;
     match winch_config::load_winch_config(dredge_path.to_string()) {
@@ -331,7 +336,7 @@ fn start_game(dredge_path : String) -> Result<(), String> {
             let home_dir = env_home.to_str().unwrap();
 
             // Aaaand PATCHING TIME! Checks if patched, if not, put reg entry in! Yay!
-            patch_protonPFX(format!("{home_dir}/.local/share/Steam/steamapps/compatdata/1562430/pfx"));
+            patch_proton_pfx(format!("{home_dir}/.local/share/Steam/steamapps/compatdata/1562430/pfx"));
 
             // Afterwards, the user can cozily run dredge via steam!!
             match Command::new("steam").args(["-applaunch", "1562430"]).spawn() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Dredge Mod Manager",
-    "version": "0.1.5"
+    "version": "0.1.6"
   },
   "tauri": {
     "allowlist": {

--- a/src/components/mods/AvailableMod.tsx
+++ b/src/components/mods/AvailableMod.tsx
@@ -29,6 +29,8 @@ export const AvailableMod = (props: IModProps) => {
     return <div className={"mods-available-box"}>
         <PrimaryContainer>
             <PrimaryDetails data={props.data}/>
+            <Downloads data={props.data}/>
+            <Version data={props.data}/>
             <InteractButtons>
                 <button className="interact-button" onClick={() => {
                     props.installMod!(props.data)
@@ -36,8 +38,6 @@ export const AvailableMod = (props: IModProps) => {
                 }}>{installText}
                 </button>
             </InteractButtons>
-            <Downloads data={props.data}/>
-            <Version data={props.data}/>
             <PrimaryExpand data={props.data} swapExpand={swapExpanded} expanded={expanded}/>
         </PrimaryContainer>
         <PrimaryContainer>

--- a/src/components/mods/AvailableMod.tsx
+++ b/src/components/mods/AvailableMod.tsx
@@ -29,8 +29,6 @@ export const AvailableMod = (props: IModProps) => {
     return <div className={"mods-available-box"}>
         <PrimaryContainer>
             <PrimaryDetails data={props.data}/>
-            <Downloads data={props.data}/>
-            <Version data={props.data}/>
             <InteractButtons>
                 <button className="interact-button" onClick={() => {
                     props.installMod!(props.data)
@@ -38,6 +36,8 @@ export const AvailableMod = (props: IModProps) => {
                 }}>{installText}
                 </button>
             </InteractButtons>
+            <Downloads data={props.data}/>
+            <Version data={props.data}/>
             <PrimaryExpand data={props.data} swapExpand={swapExpanded} expanded={expanded}/>
         </PrimaryContainer>
         <PrimaryContainer>


### PR DESCRIPTION
Adding these environment variables will ensure that wine runs and preloads the winhttp dll of the modloader instead of the builtin one.