### PR TITLE
Make Tauri app use relative path for Wineprefix (Steam, Linux) 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, ubuntu-latest]
+        platform: [windows-latest, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -64,7 +64,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo add-apt-repository 'deb http://gb.archive.ubuntu.com/ubuntu jammy main'
           sudo add-apt-repository 'deb http://gb.archive.ubuntu.com/ubuntu jammy-security main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
   create-release:
     permissions:
       contents: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       release_id: ${{ steps.create-release.outputs.result }}
 
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, ubuntu-22.04]
+        platform: [windows-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -64,7 +64,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo add-apt-repository 'deb http://gb.archive.ubuntu.com/ubuntu jammy main'
           sudo add-apt-repository 'deb http://gb.archive.ubuntu.com/ubuntu jammy-security main'
@@ -88,7 +88,7 @@ jobs:
   publish-release:
     permissions:
       contents: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [create-release, build-tauri]
 
     steps:

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -329,18 +329,14 @@ fn start_game(dredge_path : String) -> Result<(), String> {
         if is_steam {
             println!("DEBUG: Running on LINUX/STEAM.");
 
-            // Get user's steam prefix...
-            let env_home = env::var_os("HOME").unwrap();
-            let home_dir = env_home.to_str().unwrap();
-
             // Aaaand PATCHING TIME! Checks if patched, if not, put reg entry in! Yay!
-            patch_proton_pfx(format!("{home_dir}/.local/share/Steam/steamapps/compatdata/1562430/pfx"));
+            patch_proton_pfx(format!("{dredge_path}/../../compatdata/1562430/pfx"));
 
             // Afterwards, the user can cozily run dredge via steam!!
             match Command::new("steam").args(["-applaunch", "1562430"]).spawn() {
                 Ok(_) => return Ok(()),
                 Err(_) => return Err("Failed to start DREDGE.exe. Is the game directory correct?".to_string())
-            } 
+            }
         }
 
         else {


### PR DESCRIPTION
Closes #77 

The Tauri app assumes Steam Linux users have Dredge installed within the Steam library within their home folder. Using a relative path from the user-provided `dredge_path` by going up a couple directories then into `compatdata` solves the issue.

Built and tested. Evidence of the game running modded now:
<img width="855" height="651" alt="image" src="https://github.com/user-attachments/assets/9247cb65-ee4e-4123-8e64-16074d8841b7" />